### PR TITLE
Only clear intervals added after module load

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+vNEXT / 2016-06-13
+==================
+
+  * Override `setInterval` with a listener that explicitly tracks IDs, and only clear intervals that are pending since installing the listener
+
 1.0.0 / 2016-05-30
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,34 +1,56 @@
 'use strict';
 
-// Track the previous interval ID
-var prev = 0;
+// XXX(ndhoule): Handle on Function#apply to get around IE7/8 ghettry
+var apply = Function.prototype.apply;
+
+// Keep a handle on original timer globals
+var nativeSetInterval = global.setInterval;
+var nativeClearTimeout = global.clearInterval;
+
+// Track a list of interval IDs
+var intervalIds = [];
 
 /**
- * no-op.
- *
- * @return {undefined}
+ * Clear a list of setTimeout timer IDs.
  */
-function noop() {}
-
-/**
- * Clear all intervals.
- *
- * @api public
- */
-
 function clearIntervals() {
-  var tmp;
-  var i;
-
-  tmp = i = setInterval(noop);
-  while (prev < i) {
-    clearInterval(i--);
+  for (var i = 0; i < intervalIds.length; i += 1) {
+    nativeClearTimeout(intervalIds[i]);
   }
-  prev = tmp;
+
+  // Reset the list of tracked timeout IDs
+  intervalIds.length = 0;
 }
+
+/**
+ * Override `global.setInterval` with a function that tracks all setInterval
+ * timer IDs and then delegates to `global.setInterval`.
+ *
+ * Note that any intervals that were in effect prior to installing the tracker will *not* be cleared.
+ *
+ * @param {Object} [context=global] The context to override `setInterval` in.
+ */
+function installMockSetInterval(context) {
+  context = context || global;
+  // Reset the list of tracked timeout IDs
+  intervalIds.length = 0;
+
+  // IE7/8: Move setTimeout off proto and onto instance
+  global.setInterval = global.setInterval;
+  global.setInterval = function setInterval() {
+    // XXX(ndhoule): IE7/8 are ghetto so setInterval.proto !== Function.proto
+    var id = apply.call(nativeSetInterval, global, arguments);
+    intervalIds.push(id);
+    return id;
+  };
+}
+
+// Automatically override `global.setInterval` and start tracking timeout IDs
+installMockSetInterval();
 
 /*
  * Exports.
  */
 
 module.exports = clearIntervals;
+module.exports.install = installMockSetInterval;


### PR DESCRIPTION
This commit changes this module to override `global.setInterval` with a
listener that explicitly tracks IDs, and only clear intervals that were
added after the listener was installed.

This lets us avoid clearing intervals that Karma/Mocha/etc. need to
operate.
